### PR TITLE
Fix: Ensure settings persistence and immediate autostart application.

### DIFF
--- a/AudioMonitorSolution/AudioMonitor.Core/Services/SettingsService.cs
+++ b/AudioMonitorSolution/AudioMonitor.Core/Services/SettingsService.cs
@@ -14,7 +14,7 @@ namespace AudioMonitor.Core.Services
         private static readonly string ConfigFileName = "config.json";
         // In a real app, use Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
         // For this sandboxed environment, we'll place it in a known subfolder of the app's base directory.
-        private static readonly string ConfigDirectory = Path.Combine(AppContext.BaseDirectory, "AppData"); 
+        private static readonly string ConfigDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "AudioMonitor"); 
         private static readonly string ConfigFilePath = Path.Combine(ConfigDirectory, ConfigFileName);
 
         private JsonSerializerOptions _jsonOptions;

--- a/AudioMonitorSolution/AudioMonitor.Core/Services/SettingsServiceTests.cs
+++ b/AudioMonitorSolution/AudioMonitor.Core/Services/SettingsServiceTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AudioMonitor.Core.Models;
+using AudioMonitor.Core.Services;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json; // Required for direct comparison if needed, and for JsonStringEnumConverter
+
+namespace AudioMonitor.Core.Tests
+{
+    [TestClass]
+    public class SettingsServiceTests
+    {
+        private SettingsService _settingsService;
+        private string _testConfigFilePath; // To store the actual path used by SettingsService
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _settingsService = new SettingsService();
+
+            // Construct the expected path to clean up correctly.
+            // This mirrors the logic in SettingsService for determining the path.
+            string configDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "AudioMonitor");
+            _testConfigFilePath = Path.Combine(configDir, "config.json");
+
+            // Clean up any existing config file from previous test runs before each test.
+            if (File.Exists(_testConfigFilePath))
+            {
+                File.Delete(_testConfigFilePath);
+            }
+        }
+
+        [TestMethod]
+        public void SaveAndLoadSettings_ShouldPreserveSettings()
+        {
+            // Arrange
+            var originalSettings = ApplicationSettings.GetDefault();
+            originalSettings.SelectedAudioDeviceId = "test-device-id";
+            originalSettings.OverlayPosition = OverlayEdge.Bottom;
+            originalSettings.OverlayHeight = 25;
+            originalSettings.AcousticWarningEnabled = true;
+            originalSettings.AcousticWarningVolume = 0.55;
+            originalSettings.AutostartEnabled = true;
+            originalSettings.WarningLevels.Thresholds.Add(new ThresholdLevel("TestLevel", -5, "#123456"));
+            originalSettings.WarningLevels.SortThresholds(); // Ensure it's sorted before comparison
+
+            // Act
+            _settingsService.SaveApplicationSettings(originalSettings);
+            var loadedSettings = _settingsService.LoadApplicationSettings();
+
+            // Assert
+            Assert.IsNotNull(loadedSettings);
+            Assert.AreEqual(originalSettings.SelectedAudioDeviceId, loadedSettings.SelectedAudioDeviceId);
+            Assert.AreEqual(originalSettings.OverlayPosition, loadedSettings.OverlayPosition);
+            Assert.AreEqual(originalSettings.OverlayHeight, loadedSettings.OverlayHeight);
+            Assert.AreEqual(originalSettings.AcousticWarningEnabled, loadedSettings.AcousticWarningEnabled);
+            Assert.AreEqual(originalSettings.AcousticWarningVolume, loadedSettings.AcousticWarningVolume, 0.001); // Delta for double
+            Assert.AreEqual(originalSettings.AutostartEnabled, loadedSettings.AutostartEnabled);
+
+            Assert.IsNotNull(loadedSettings.WarningLevels);
+            Assert.IsNotNull(loadedSettings.WarningLevels.Thresholds);
+            Assert.AreEqual(originalSettings.WarningLevels.Thresholds.Count, loadedSettings.WarningLevels.Thresholds.Count);
+
+            // Sort both by DBFSValue then Name to ensure order for comparison
+            var originalThresholds = originalSettings.WarningLevels.Thresholds.OrderBy(t => t.DBFSValue).ThenBy(t => t.Name).ToList();
+            var loadedThresholds = loadedSettings.WarningLevels.Thresholds.OrderBy(t => t.DBFSValue).ThenBy(t => t.Name).ToList();
+
+            for (int i = 0; i < originalThresholds.Count; i++)
+            {
+                Assert.AreEqual(originalThresholds[i].Name, loadedThresholds[i].Name);
+                Assert.AreEqual(originalThresholds[i].DBFSValue, loadedThresholds[i].DBFSValue, 0.001);
+                Assert.AreEqual(originalThresholds[i].Color, loadedThresholds[i].Color);
+            }
+        }
+
+        [TestMethod]
+        public void LoadSettings_WhenNoFileExists_ReturnsDefaultSettings()
+        {
+            // Arrange (ensure no file exists - Setup does this)
+
+            // Act
+            var loadedSettings = _settingsService.LoadApplicationSettings();
+
+            // Assert
+            var defaultSettings = ApplicationSettings.GetDefault();
+            Assert.IsNotNull(loadedSettings);
+            // Check a few key default properties
+            Assert.AreEqual(defaultSettings.OverlayPosition, loadedSettings.OverlayPosition);
+            Assert.AreEqual(defaultSettings.OverlayHeight, loadedSettings.OverlayHeight);
+            Assert.AreEqual(defaultSettings.AcousticWarningEnabled, loadedSettings.AcousticWarningEnabled);
+            Assert.AreEqual(defaultSettings.WarningLevels.Thresholds.Count, loadedSettings.WarningLevels.Thresholds.Count);
+            
+            // Verify that a new default config file was created
+            Assert.IsTrue(File.Exists(_testConfigFilePath), "A new config file should have been created with default settings.");
+        }
+        
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Clean up the config file created during the test.
+            if (File.Exists(_testConfigFilePath))
+            {
+                File.Delete(_testConfigFilePath);
+            }
+        }
+    }
+}

--- a/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml.cs
+++ b/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using AudioMonitor.UI.Views;
 using System.ComponentModel;
 using System.Runtime.InteropServices; // Required for DllImport
 using System.Windows.Interop; // Required for WindowInteropHelper
+using AudioMonitor.UI.Services;
 // We might need System.Drawing if we directly use System.Drawing.Rectangle, but Screen.Bounds is already that.
 
 namespace AudioMonitor.UI.Views
@@ -371,6 +372,7 @@ namespace AudioMonitor.UI.Views
 
                 UpdateOverlayLayout(); 
                 _settingsService.SaveApplicationSettings(_appSettings); 
+                AutostartService.SetAutostart(_appSettings.AutostartEnabled);
             }
         }
 


### PR DESCRIPTION
- I modified SettingsService to store config.json in your ApplicationData folder (under an 'AudioMonitor' subfolder). This fixes issues where settings might not be saved if the application is run from a restricted location.
- I updated MainWindow to call AutostartService.SetAutostart immediately after settings are saved. This makes changes to the autostart preference take effect without requiring an application restart.
- I added SettingsServiceTests.cs with unit tests for saving and loading settings to verify the new storage mechanism and default settings behavior.
- I reviewed application of other settings (audio device, overlay, warnings); existing logic appears to apply them correctly upon change.