### PR TITLE
Fix: Improve overlay window positioning reliability.

### DIFF
--- a/AudioMonitorSolution/AudioMonitor.OverlayRenderer/OverlayWindow.xaml
+++ b/AudioMonitorSolution/AudioMonitor.OverlayRenderer/OverlayWindow.xaml
@@ -13,7 +13,6 @@
         Left="0" Top="0"
         Loaded="Window_Loaded"
         HorizontalAlignment="Stretch" 
-        SizeToContent="Width" 
         >
     <Grid HorizontalAlignment="Stretch">
         <Rectangle x:Name="OverlayBar" Height="{Binding ActualHeight, RelativeSource={RelativeSource AncestorType=Window}}" VerticalAlignment="Top" HorizontalAlignment="Stretch"/>


### PR DESCRIPTION
Removed `SizeToContent="Width"` from OverlayWindow.xaml. This attribute could potentially conflict with the explicit sizing performed by the `SetOverlayPositionAndSize` method, especially for vertical (Left/Right) overlay placements. The window dimensions are managed programmatically, making this attribute unnecessary and its removal helps prevent unexpected layout behavior.