### PR TITLE
feat: Implement internationalization for English and German

### DIFF
--- a/AudioMonitorSolution/AudioMonitor.Core/Models/ApplicationSettings.cs
+++ b/AudioMonitorSolution/AudioMonitor.Core/Models/ApplicationSettings.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace AudioMonitor.Core.Models
 {
     public enum OverlayEdge
@@ -11,6 +13,7 @@ namespace AudioMonitor.Core.Models
     public class ApplicationSettings
     {
         public string? SelectedAudioDeviceId { get; set; }
+        public string LanguageCode { get; set; }
         public OverlayEdge OverlayPosition { get; set; }
         public int OverlayThickness { get; set; } // Changed from OverlayHeight
         public bool AcousticWarningEnabled { get; set; }
@@ -36,6 +39,17 @@ namespace AudioMonitor.Core.Models
             ThresholdSafe = -12;
             ThresholdWarning = -6;
             ThresholdCritical = -3;
+
+            // Language selection
+            var currentCulture = CultureInfo.CurrentUICulture.Name;
+            if (currentCulture.StartsWith("de", StringComparison.OrdinalIgnoreCase))
+            {
+                this.LanguageCode = "de-DE";
+            }
+            else
+            {
+                this.LanguageCode = "en-US";
+            }
         }
 
         public static ApplicationSettings GetDefault()
@@ -52,8 +66,19 @@ namespace AudioMonitor.Core.Models
                 // Default threshold values
                 ThresholdSafe = -12,
                 ThresholdWarning = -6,
-                ThresholdCritical = -3
+                ThresholdCritical = -3,
             };
+
+            // Language selection
+            var currentCulture = CultureInfo.CurrentUICulture.Name;
+            if (currentCulture.StartsWith("de", StringComparison.OrdinalIgnoreCase))
+            {
+                settings.LanguageCode = "de-DE";
+            }
+            else
+            {
+                settings.LanguageCode = "en-US";
+            }
             return settings;
         }
     }

--- a/AudioMonitorSolution/AudioMonitor.UI/AudioMonitor.UI.csproj
+++ b/AudioMonitorSolution/AudioMonitor.UI/AudioMonitor.UI.csproj
@@ -18,4 +18,17 @@
     <None Remove="image.ico" />
     <Resource Include="image.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Strings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Strings.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/AudioMonitorSolution/AudioMonitor.UI/Properties/Strings.de.resx
+++ b/AudioMonitorSolution/AudioMonitor.UI/Properties/Strings.de.resx
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+    </data>
+            
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Mimetype is used for serialized objects, and tells the reader an 
+    MIME-type that the object belongs to. Specifically,
+    
+    Ozymandias (screenplay):
+    <data name="Ozymandias" xml:space="preserve">
+        <value>I met a traveller from an antique land,
+        Who said—“Two vast and trunkless legs of stone
+        Stand in the desert ... Nothing beside remains. 
+        Round the decay
+        Of that colossal Wreck, boundless and bare
+        The lone and level sands stretch far away.”</value>
+    </data>
+    
+    Otherwise, the xml:space="preserve" attribute is not used on the value.
+    
+    So primary goals are:
+    1. Allow simple XML format
+    2. Human readable
+    3. Allow comments in individual data elements
+    4. Allow data elements to be typed to support simple value parameters that are not strings
+    5. Allow object serialization via mime type and base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TrayMenuShow" xml:space="preserve">
+    <value>Zeigen</value>
+  </data>
+  <data name="TrayMenuSettings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="TrayMenuExit" xml:space="preserve">
+    <value>Beenden</value>
+  </data>
+  <data name="TrayMenuResetSettings" xml:space="preserve">
+    <value>Einstellungen zurücksetzen</value>
+  </data>
+  <data name="MainWindowTitle" xml:space="preserve">
+    <value>AudioMonitor</value>
+  </data>
+  <data name="MainWindowHeader" xml:space="preserve">
+    <value>AudioMonitor</value>
+  </data>
+  <data name="SettingsButtonContent" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="MinimizeButtonContent" xml:space="preserve">
+    <value>✕</value>
+  </data>
+  <data name="AudioInputDeviceLabel" xml:space="preserve">
+    <value>Audio-Eingangsgerät</value>
+  </data>
+  <data name="RunningMessage" xml:space="preserve">
+    <value>AudioMonitor läuft und überwacht die Audiopegel in Echtzeit. Konfigurieren Sie die Einstellungen über die Schaltfläche "Einstellungen" oben.</value>
+  </data>
+  <data name="StatusLabel" xml:space="preserve">
+    <value>Status:</value>
+  </data>
+  <data name="StatusMonitoring" xml:space="preserve">
+    <value>Überwachung LÄUFT</value>
+  </data>
+  <data name="StatusPaused" xml:space="preserve">
+    <value>Pausiert</value>
+  </data>
+  <data name="ResetSettingsConfirmTitle" xml:space="preserve">
+    <value>Einstellungen zurücksetzen</value>
+  </data>
+  <data name="ResetSettingsConfirmMessage" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie alle Einstellungen auf ihre Standardwerte zurücksetzen möchten?</value>
+  </data>
+  <data name="ResetSettingsSuccessTitle" xml:space="preserve">
+    <value>Einstellungen zurückgesetzt</value>
+  </data>
+  <data name="ResetSettingsSuccessMessage" xml:space="preserve">
+    <value>Die Einstellungen wurden auf die Standardwerte zurückgesetzt.</value>
+  </data>
+  <data name="LoadSettingsErrorTitle" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="LoadSettingsErrorMessage" xml:space="preserve">
+    <value>Fehler beim Laden der Anwendungseinstellungen. Die Anwendung funktioniert möglicherweise nicht korrekt.</value>
+  </data>
+  <data name="PrepareSettingsErrorTitle" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="PrepareSettingsErrorMessage" xml:space="preserve">
+    <value>Fehler beim Vorbereiten der Einstellungen. Bitte versuchen Sie es erneut.</value>
+  </data>
+  <data name="CloneSettingsErrorTitle" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="CloneSettingsErrorMessage" xml:space="preserve">
+    <value>Fehler beim Klonen der Anwendungseinstellungen (Ergebnis war null).</value>
+  </data>
+  <data name="CreateSettingsWindowErrorTitle" xml:space="preserve">
+    <value>Fehler Einstellungsfenster</value>
+  </data>
+  <data name="CreateSettingsWindowErrorMessage" xml:space="preserve">
+    <value>Fehler beim Erstellen des Einstellungsfensters: {0}</value>
+  </data>
+  <data name="ApplySettingsErrorTitle" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="ApplySettingsErrorMessage" xml:space="preserve">
+    <value>Fehler beim Anwenden der Einstellungen. Änderungen wurden möglicherweise nicht gespeichert.</value>
+  </data>
+  <data name="ShowSettingsDialogErrorTitle" xml:space="preserve">
+    <value>Fehler Einstellungsdialog</value>
+  </data>
+  <data name="ShowSettingsDialogErrorMessage" xml:space="preserve">
+    <value>Fehler beim Anzeigen des Einstellungsdialogs: {0}</value>
+  </data>
+  <data name="ToolTipMonitoring" xml:space="preserve">
+    <value>AudioMonitor (Überwachung LÄUFT)</value>
+  </data>
+  <data name="ToolTipCritical" xml:space="preserve">
+    <value>AudioMonitor (KRITISCH!)</value>
+  </data>
+  <data name="ToolTipPaused" xml:space="preserve">
+    <value>AudioMonitor (Pausiert)</value>
+  </data>
+  <data name="SettingsWindowTitle" xml:space="preserve">
+    <value>AudioMonitor Einstellungen</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="AudioInputDeviceSectionHeader" xml:space="preserve">
+    <value>Audio-Eingangsgerät</value>
+  </data>
+  <data name="LiveAudioLevelDisplayHeader" xml:space="preserve">
+    <value>Aktueller Audiopegel</value>
+  </data>
+  <data name="CurrentLevelLabel" xml:space="preserve">
+    <value>Aktueller Pegel: {0} dBFS</value>
+  </data>
+  <data name="PeakLevelLabel" xml:space="preserve">
+    <value>Peak: {0} dBFS</value>
+  </data>
+  <data name="ThresholdConfigSectionHeader" xml:space="preserve">
+    <value>Warnschwellenwerte Konfiguration</value>
+  </data>
+  <data name="ThresholdConfigDescription" xml:space="preserve">
+    <value>Pegelstufen und zugehörige dBFS-Schwellenwerte definieren.</value>
+  </data>
+  <data name="ThresholdSafeLabel" xml:space="preserve">
+    <value>Sicher (Grün) bis:</value>
+  </data>
+  <data name="ThresholdWarningLabel" xml:space="preserve">
+    <value>Achtung (Gelb) bis:</value>
+  </data>
+  <data name="ThresholdCriticalLabel" xml:space="preserve">
+    <value>Kritisch (Rot) ab:</value>
+  </data>
+  <data name="ThresholdUnitLabel" xml:space="preserve">
+    <value>dBFS</value>
+  </data>
+  <data name="ColorGradientInfo" xml:space="preserve">
+    <value>Farbverlauf: Standard Grün-Gelb-Rot. (Konfigurierbarkeit idealerweise später)</value>
+  </data>
+  <data name="VisualOverlaySectionHeader" xml:space="preserve">
+    <value>Visuelles Overlay</value>
+  </data>
+  <data name="OverlayPositionLabel" xml:space="preserve">
+    <value>Position (Monitorrand):</value>
+  </data>
+  <data name="OverlayPositionTop" xml:space="preserve">
+    <value>Oberer Rand</value>
+  </data>
+  <data name="OverlayPositionBottom" xml:space="preserve">
+    <value>Unterer Rand</value>
+  </data>
+  <data name="OverlayPositionLeft" xml:space="preserve">
+    <value>Linker Rand</value>
+  </data>
+  <data name="OverlayPositionRight" xml:space="preserve">
+    <value>Rechter Rand</value>
+  </data>
+  <data name="OverlayThicknessLabel" xml:space="preserve">
+    <value>Dicke/Breite:</value>
+  </data>
+  <data name="OverlayThicknessUnitLabel" xml:space="preserve">
+    <value>px</value>
+  </data>
+  <data name="OverlayBehaviorInfo" xml:space="preserve">
+    <value>Dynamische Transparenz und Verhalten im kritischen Bereich gemäß FA04.2, FA04.3.</value>
+  </data>
+  <data name="AcousticWarningSectionHeader" xml:space="preserve">
+    <value>Akustische Warnung</value>
+  </data>
+  <data name="EnableAcousticWarningLabel" xml:space="preserve">
+    <value>Akustische Warnung (Sinuswelle) aktivieren</value>
+  </data>
+  <data name="VolumeLabel" xml:space="preserve">
+    <value>Lautstärke:</value>
+  </data>
+  <data name="SystemSettingsSectionHeader" xml:space="preserve">
+    <value>Systemeinstellungen</value>
+  </data>
+  <data name="StartWithWindowsLabel" xml:space="preserve">
+    <value>Mit Windows starten</value>
+  </data>
+  <data name="SaveSettingsButtonContent" xml:space="preserve">
+    <value>Einstellungen speichern</value>
+  </data>
+  <data name="StartMonitoringButtonContent" xml:space="preserve">
+    <value>Überwachung starten</value>
+  </data>
+  <data name="MinimizeToTrayButtonContent" xml:space="preserve">
+    <value>In Tray minimieren</value>
+  </data>
+  <data name="SettingsWindowErrorTitle" xml:space="preserve">
+    <value>Fehler Einstellungsfenster</value>
+  </data>
+  <data name="SettingsWindowErrorMessage" xml:space="preserve">
+    <value>Fehler im SettingsWindow-Konstruktor: {0}
+
+Stacktrace:
+{1}</value>
+  </data>
+  <data name="MonitoringInfoTitle" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="MonitoringInfoMessage" xml:space="preserve">
+    <value>Die Überwachung wird mit den neuen Einstellungen gestartet, nachdem dieses Fenster geschlossen wurde.</value>
+  </data>
+  <data name="DeviceTypeWASAPI" xml:space="preserve">
+    <value>WASAPI-Geräte</value>
+  </data>
+  <data name="DeviceTypeASIO" xml:space="preserve">
+    <value>ASIO-Geräte</value>
+  </data>
+  <data name="DeviceTypeOther" xml:space="preserve">
+    <value>Andere Geräte</value>
+  </data>
+  <data name="DeviceTypeUnknown" xml:space="preserve">
+    <value>Unbekannt</value>
+  </data>
+  <data name="LanguageSelectionLabel" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="LanguageChangedTitle" xml:space="preserve">
+    <value>Sprache geändert</value>
+  </data>
+  <data name="LanguageChangedMessage" xml:space="preserve">
+    <value>Die Sprache wurde geändert. Bitte starten Sie die Anwendung neu, damit die Änderungen vollständig wirksam werden.</value>
+  </data>
+  <data name="StatusCritical" xml:space="preserve">
+    <value>KRITISCH!</value>
+  </data>
+  <data name="CurrentLevelPlaceholder" xml:space="preserve">
+    <value>Aktueller Pegel: -- dBFS</value>
+  </data>
+  <data name="PeakLevelPlaceholder" xml:space="preserve">
+    <value>Peak: -- dBFS</value>
+  </data>
+</root>

--- a/AudioMonitorSolution/AudioMonitor.UI/Properties/Strings.resx
+++ b/AudioMonitorSolution/AudioMonitor.UI/Properties/Strings.resx
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+    </data>
+            
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Mimetype is used for serialized objects, and tells the reader an 
+    MIME-type that the object belongs to. Specifically,
+    
+    Ozymandias (screenplay):
+    <data name="Ozymandias" xml:space="preserve">
+        <value>I met a traveller from an antique land,
+        Who said—“Two vast and trunkless legs of stone
+        Stand in the desert ... Nothing beside remains. 
+        Round the decay
+        Of that colossal Wreck, boundless and bare
+        The lone and level sands stretch far away.”</value>
+    </data>
+    
+    Otherwise, the xml:space="preserve" attribute is not used on the value.
+    
+    So primary goals are:
+    1. Allow simple XML format
+    2. Human readable
+    3. Allow comments in individual data elements
+    4. Allow data elements to be typed to support simple value parameters that are not strings
+    5. Allow object serialization via mime type and base64 encoding.
+  -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TrayMenuShow" xml:space="preserve">
+    <value>Show</value>
+  </data>
+  <data name="TrayMenuSettings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="TrayMenuExit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="TrayMenuResetSettings" xml:space="preserve">
+    <value>Reset Settings</value>
+  </data>
+  <data name="MainWindowTitle" xml:space="preserve">
+    <value>AudioMonitor</value>
+  </data>
+  <data name="MainWindowHeader" xml:space="preserve">
+    <value>AudioMonitor</value>
+  </data>
+  <data name="SettingsButtonContent" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="MinimizeButtonContent" xml:space="preserve">
+    <value>✕</value>
+  </data>
+  <data name="AudioInputDeviceLabel" xml:space="preserve">
+    <value>Audio Input Device</value>
+  </data>
+  <data name="RunningMessage" xml:space="preserve">
+    <value>AudioMonitor is running and monitoring audio levels in real-time. Configure settings using the Settings button above.</value>
+  </data>
+  <data name="StatusLabel" xml:space="preserve">
+    <value>Status:</value>
+  </data>
+  <data name="StatusMonitoring" xml:space="preserve">
+    <value>Monitoring</value>
+  </data>
+  <data name="StatusPaused" xml:space="preserve">
+    <value>Paused</value>
+  </data>
+  <data name="ResetSettingsConfirmTitle" xml:space="preserve">
+    <value>Reset Settings</value>
+  </data>
+  <data name="ResetSettingsConfirmMessage" xml:space="preserve">
+    <value>Are you sure you want to reset all settings to their default values?</value>
+  </data>
+  <data name="ResetSettingsSuccessTitle" xml:space="preserve">
+    <value>Settings Reset</value>
+  </data>
+  <data name="ResetSettingsSuccessMessage" xml:space="preserve">
+    <value>Settings have been reset to default.</value>
+  </data>
+  <data name="LoadSettingsErrorTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="LoadSettingsErrorMessage" xml:space="preserve">
+    <value>Failed to load application settings. Application might not work correctly.</value>
+  </data>
+  <data name="PrepareSettingsErrorTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="PrepareSettingsErrorMessage" xml:space="preserve">
+    <value>Error preparing settings. Please try again.</value>
+  </data>
+  <data name="CloneSettingsErrorTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="CloneSettingsErrorMessage" xml:space="preserve">
+    <value>Failed to clone application settings (result was null).</value>
+  </data>
+  <data name="CreateSettingsWindowErrorTitle" xml:space="preserve">
+    <value>Settings Window Error</value>
+  </data>
+  <data name="CreateSettingsWindowErrorMessage" xml:space="preserve">
+    <value>Error creating settings window: {0}</value>
+  </data>
+  <data name="ApplySettingsErrorTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="ApplySettingsErrorMessage" xml:space="preserve">
+    <value>Failed to apply settings. Changes may not have been saved.</value>
+  </data>
+  <data name="ShowSettingsDialogErrorTitle" xml:space="preserve">
+    <value>Settings Dialog Error</value>
+  </data>
+  <data name="ShowSettingsDialogErrorMessage" xml:space="preserve">
+    <value>Error displaying settings dialog: {0}</value>
+  </data>
+  <data name="ToolTipMonitoring" xml:space="preserve">
+    <value>AudioMonitor (Monitoring)</value>
+  </data>
+  <data name="ToolTipCritical" xml:space="preserve">
+    <value>AudioMonitor (CRITICAL!)</value>
+  </data>
+  <data name="ToolTipPaused" xml:space="preserve">
+    <value>AudioMonitor (Paused)</value>
+  </data>
+  <data name="SettingsWindowTitle" xml:space="preserve">
+    <value>AudioMonitor Settings</value>
+  </data>
+  <data name="SettingsHeader" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="AudioInputDeviceSectionHeader" xml:space="preserve">
+    <value>Audio Input Device</value>
+  </data>
+  <data name="LiveAudioLevelDisplayHeader" xml:space="preserve">
+    <value>Live Audio Level</value>
+  </data>
+  <data name="CurrentLevelLabel" xml:space="preserve">
+    <value>Current Level: {0} dBFS</value>
+  </data>
+  <data name="PeakLevelLabel" xml:space="preserve">
+    <value>Peak: {0} dBFS</value>
+  </data>
+  <data name="ThresholdConfigSectionHeader" xml:space="preserve">
+    <value>Threshold Configuration</value>
+  </data>
+  <data name="ThresholdConfigDescription" xml:space="preserve">
+    <value>Define level stages and their corresponding dBFS thresholds.</value>
+  </data>
+  <data name="ThresholdSafeLabel" xml:space="preserve">
+    <value>Safe (Green) up to:</value>
+  </data>
+  <data name="ThresholdWarningLabel" xml:space="preserve">
+    <value>Warning (Yellow) up to:</value>
+  </data>
+  <data name="ThresholdCriticalLabel" xml:space="preserve">
+    <value>Critical (Red) from:</value>
+  </data>
+  <data name="ThresholdUnitLabel" xml:space="preserve">
+    <value>dBFS</value>
+  </data>
+  <data name="ColorGradientInfo" xml:space="preserve">
+    <value>Color gradient: Standard Green-Yellow-Red. (Configurability ideally later)</value>
+  </data>
+  <data name="VisualOverlaySectionHeader" xml:space="preserve">
+    <value>Visual Overlay</value>
+  </data>
+  <data name="OverlayPositionLabel" xml:space="preserve">
+    <value>Position (Monitor Edge):</value>
+  </data>
+  <data name="OverlayPositionTop" xml:space="preserve">
+    <value>Top Edge</value>
+  </data>
+  <data name="OverlayPositionBottom" xml:space="preserve">
+    <value>Bottom Edge</value>
+  </data>
+  <data name="OverlayPositionLeft" xml:space="preserve">
+    <value>Left Edge</value>
+  </data>
+  <data name="OverlayPositionRight" xml:space="preserve">
+    <value>Right Edge</value>
+  </data>
+  <data name="OverlayThicknessLabel" xml:space="preserve">
+    <value>Thickness/Width:</value>
+  </data>
+  <data name="OverlayThicknessUnitLabel" xml:space="preserve">
+    <value>px</value>
+  </data>
+  <data name="OverlayBehaviorInfo" xml:space="preserve">
+    <value>Dynamic transparency and behavior in critical range as per FA04.2, FA04.3.</value>
+  </data>
+  <data name="AcousticWarningSectionHeader" xml:space="preserve">
+    <value>Acoustic Warning</value>
+  </data>
+  <data name="EnableAcousticWarningLabel" xml:space="preserve">
+    <value>Enable acoustic warning (sine wave)</value>
+  </data>
+  <data name="VolumeLabel" xml:space="preserve">
+    <value>Volume:</value>
+  </data>
+  <data name="SystemSettingsSectionHeader" xml:space="preserve">
+    <value>System Settings</value>
+  </data>
+  <data name="StartWithWindowsLabel" xml:space="preserve">
+    <value>Start with Windows</value>
+  </data>
+  <data name="SaveSettingsButtonContent" xml:space="preserve">
+    <value>Save Settings</value>
+  </data>
+  <data name="StartMonitoringButtonContent" xml:space="preserve">
+    <value>Start Monitoring</value>
+  </data>
+  <data name="MinimizeToTrayButtonContent" xml:space="preserve">
+    <value>Minimize to Tray</value>
+  </data>
+  <data name="SettingsWindowErrorTitle" xml:space="preserve">
+    <value>SettingsWindow Error</value>
+  </data>
+  <data name="SettingsWindowErrorMessage" xml:space="preserve">
+    <value>Error in SettingsWindow constructor: {0}
+
+Stack trace:
+{1}</value>
+  </data>
+  <data name="MonitoringInfoTitle" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="MonitoringInfoMessage" xml:space="preserve">
+    <value>Monitoring will start with the new settings after this window is closed.</value>
+  </data>
+  <data name="DeviceTypeWASAPI" xml:space="preserve">
+    <value>WASAPI Devices</value>
+  </data>
+  <data name="DeviceTypeASIO" xml:space="preserve">
+    <value>ASIO Devices</value>
+  </data>
+  <data name="DeviceTypeOther" xml:space="preserve">
+    <value>Other Devices</value>
+  </data>
+  <data name="DeviceTypeUnknown" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="LanguageSelectionLabel" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="LanguageChangedTitle" xml:space="preserve">
+    <value>Language Changed</value>
+  </data>
+  <data name="LanguageChangedMessage" xml:space="preserve">
+    <value>The language has been changed. Please restart the application for the changes to take full effect.</value>
+  </data>
+  <data name="StatusCritical" xml:space="preserve">
+    <value>Critical!</value>
+  </data>
+  <data name="CurrentLevelPlaceholder" xml:space="preserve">
+    <value>Current Level: -- dBFS</value>
+  </data>
+  <data name="PeakLevelPlaceholder" xml:space="preserve">
+    <value>Peak: -- dBFS</value>
+  </data>
+</root>

--- a/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml
+++ b/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:tb="http://www.hardcodet.net/taskbar"
         xmlns:local="clr-namespace:AudioMonitor.UI.Views"
-        Title="AudioMonitor" Height="500" Width="900"
+        xmlns:p="clr-namespace:AudioMonitor.UI.Properties"
+        Title="{x:Static p:Strings.MainWindowTitle}" Height="500" Width="900"
         MinHeight="400" MinWidth="600"
         Background="Transparent"
         WindowStyle="None"
@@ -15,12 +16,12 @@
     <Window.Resources>
         <tb:TaskbarIcon x:Name="MyNotifyIcon" x:Key="MyNotifyIconResource"
                         IconSource="/image.ico"
-                        ToolTipText="AudioMonitor UI">
+                        ToolTipText="{x:Static p:Strings.MainWindowTitle}">
             <tb:TaskbarIcon.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Header="Show" Click="ShowMenuItem_Click"/>
-                    <MenuItem Header="Settings" Click="SettingsMenuItem_Click"/>
-                    <MenuItem Header="Exit" Click="ExitMenuItem_Click"/>
+                    <MenuItem Header="{x:Static p:Strings.TrayMenuShow}" Click="ShowMenuItem_Click"/>
+                    <MenuItem Header="{x:Static p:Strings.TrayMenuSettings}" Click="SettingsMenuItem_Click"/>
+                    <MenuItem Header="{x:Static p:Strings.TrayMenuExit}" Click="ExitMenuItem_Click"/>
                 </ContextMenu>
             </tb:TaskbarIcon.ContextMenu>
         </tb:TaskbarIcon>
@@ -234,13 +235,13 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     
-                    <TextBlock Text="AudioMonitor" 
+                    <TextBlock Text="{x:Static p:Strings.MainWindowHeader}" 
                                FontSize="20" 
                                FontWeight="SemiBold"
                                Foreground="{StaticResource TextColorPrimary}"
                                VerticalAlignment="Center"/>
                       <StackPanel Grid.Column="1" Orientation="Horizontal">
-                        <Button Content="Settings" 
+                        <Button Content="{x:Static p:Strings.SettingsButtonContent}" 
                                 Style="{StaticResource ModernButtonStyle}"
                                 Click="SettingsMenuItem_Click"
                                 Margin="10,0"/>
@@ -262,7 +263,7 @@
                 </Grid.RowDefinitions>
                 
                 <TextBlock Grid.Row="0"
-                          Text="Audio Input Device" 
+                          Text="{x:Static p:Strings.AudioInputDeviceLabel}" 
                           FontSize="16" 
                           FontWeight="SemiBold"
                           Foreground="{StaticResource TextColorPrimary}"
@@ -293,7 +294,7 @@
                 </ComboBox>
                 
                 <TextBlock Grid.Row="2"
-                          Text="AudioMonitor is running and monitoring audio levels in real-time. Configure settings using the Settings button above."
+                          Text="{x:Static p:Strings.RunningMessage}"
                           FontSize="14"
                           Foreground="{StaticResource TextColorSecondary}"
                           TextWrapping="Wrap"
@@ -308,7 +309,7 @@
                     BorderThickness="0,1,0,0"
                     Padding="20,10">
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                    <TextBlock Text="Status: Monitoring" 
+                    <TextBlock x:Name="StatusTextBlock" Text="{Binding StatusText, FallbackValue='Status: Monitoring'}" 
                               FontSize="12"
                               Foreground="{StaticResource AccentColorGreen}"
                               VerticalAlignment="Center"

--- a/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml.cs
+++ b/AudioMonitorSolution/AudioMonitor.UI/Views/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using System.Windows.Data;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO; // Required for Path operations
+using AudioMonitor.UI.Properties;
 // We might need System.Drawing if we directly use System.Drawing.Rectangle, but Screen.Bounds is already that.
 
 namespace AudioMonitor.UI.Views
@@ -107,8 +108,8 @@ namespace AudioMonitor.UI.Views
 
         private void ResetSettingsMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            if (MessageBox.Show("Are you sure you want to reset all settings to their default values?",
-                                "Reset Settings", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+            if (MessageBox.Show(Strings.ResetSettingsConfirmMessage,
+                                Strings.ResetSettingsConfirmTitle, MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
             {
                 if (_settingsService != null && _appSettings != null)
                 {
@@ -170,7 +171,7 @@ namespace AudioMonitor.UI.Views
                     InitializeOverlays(); // Re-initialize overlays
                     AutostartService.SetAutostart(_appSettings.AutostartEnabled);
 
-                    MessageBox.Show("Settings have been reset to default.", "Settings Reset", MessageBoxButton.OK, MessageBoxImage.Information);
+                    MessageBox.Show(Strings.ResetSettingsSuccessMessage, Strings.ResetSettingsSuccessTitle, MessageBoxButton.OK, MessageBoxImage.Information);
                 }
             }
         }
@@ -206,7 +207,7 @@ namespace AudioMonitor.UI.Views
             // Programmatically add "Reset Settings" menu item
             if (_myNotifyIcon != null && _myNotifyIcon.ContextMenu != null)
             {
-                var resetSettingsMenuItem = new System.Windows.Controls.MenuItem { Header = "Reset Settings" };
+                var resetSettingsMenuItem = new System.Windows.Controls.MenuItem { Header = Strings.TrayMenuResetSettings };
                 resetSettingsMenuItem.Click += ResetSettingsMenuItem_Click;
 
                 // Insert before the "Exit" item, or at a specific position
@@ -245,7 +246,7 @@ namespace AudioMonitor.UI.Views
 
             if (_appSettings == null) // Should not happen if GetDefault works
             {
-                MessageBox.Show("Failed to load application settings. Application might not work correctly.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Strings.LoadSettingsErrorMessage, Strings.LoadSettingsErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 // Consider closing or using hardcoded defaults
                 _appSettings = ApplicationSettings.GetDefault(); 
             }            _levelAnalyzer = new LevelAnalyzer(_appSettings.WarningLevels);
@@ -438,18 +439,21 @@ namespace AudioMonitor.UI.Views
 
             if (!isMonitoring)
             {
-                _myNotifyIcon.ToolTipText = "AudioMonitor (Paused)";
+                _myNotifyIcon.ToolTipText = Strings.ToolTipPaused;
+                StatusTextBlock.Text = $"{Strings.StatusLabel} {Strings.StatusPaused}";
                 // TODO: Update _myNotifyIcon.IconSource for paused state if a specific icon is available
                 // Example: _myNotifyIcon.IconSource = new BitmapImage(new Uri("pack://application:,,,/YourAppAssemblyName;component/Resources/icon_paused.ico"));
             }
             else if (isCritical)
             {
-                _myNotifyIcon.ToolTipText = "AudioMonitor (CRITICAL!)";
+                _myNotifyIcon.ToolTipText = Strings.ToolTipCritical;
+                StatusTextBlock.Text = $"{Strings.StatusLabel} {Strings.StatusCritical}"; // Assuming StatusCritical exists or use Monitoring
                 // TODO: Update _myNotifyIcon.IconSource for critical state
             }
             else
             {
-                _myNotifyIcon.ToolTipText = "AudioMonitor (Monitoring)";
+                _myNotifyIcon.ToolTipText = Strings.ToolTipMonitoring;
+                StatusTextBlock.Text = $"{Strings.StatusLabel} {Strings.StatusMonitoring}";
                 // TODO: Update _myNotifyIcon.IconSource for normal monitoring state (back to default)
             }
         }        public void ShowSettings()
@@ -464,14 +468,14 @@ namespace AudioMonitor.UI.Views
             catch (System.Text.Json.JsonException ex)
             {
                 Core.Logging.Log.Error("Failed to clone application settings for SettingsWindow.", ex);
-                MessageBox.Show("Error preparing settings. Please try again.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Strings.PrepareSettingsErrorMessage, Strings.PrepareSettingsErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
             if (settingsCopy == null)
             {
                 Core.Logging.Log.Error("Failed to clone application settings (result was null).");
-                MessageBox.Show("Error preparing settings. Please try again.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(Strings.CloneSettingsErrorMessage, Strings.CloneSettingsErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -482,7 +486,7 @@ namespace AudioMonitor.UI.Views
             catch (Exception ex)
             {
                 Core.Logging.Log.Error("Failed to create SettingsWindow.", ex);
-                MessageBox.Show($"Error creating settings window: {ex.Message}", "Settings Window Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(string.Format(Strings.CreateSettingsWindowErrorMessage, ex.Message), Strings.CreateSettingsWindowErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 
@@ -494,7 +498,7 @@ namespace AudioMonitor.UI.Views
                     if (newSettings == null)
                     {
                         Core.Logging.Log.Error("SettingsWindow returned null settings after dialog confirmation.");
-                        MessageBox.Show("Failed to apply settings. Changes may not have been saved.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        MessageBox.Show(Strings.ApplySettingsErrorMessage, Strings.ApplySettingsErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
                         return;
                     }
                     _appSettings = newSettings; 
@@ -523,7 +527,7 @@ namespace AudioMonitor.UI.Views
             catch (Exception ex)
             {
                 Core.Logging.Log.Error("Error showing SettingsWindow dialog.", ex);
-                MessageBox.Show($"Error displaying settings dialog: {ex.Message}", "Settings Dialog Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(string.Format(Strings.ShowSettingsDialogErrorMessage, ex.Message), Strings.ShowSettingsDialogErrorTitle, MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 

--- a/AudioMonitorSolution/AudioMonitor.UI/Views/SettingsWindow.xaml
+++ b/AudioMonitorSolution/AudioMonitor.UI/Views/SettingsWindow.xaml
@@ -2,7 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:AudioMonitor.UI.Views"
-        Title="Audio-Pegelwarnung für Focusrite Scarlett - Einstellungen" 
+        xmlns:p="clr-namespace:AudioMonitor.UI.Properties"
+        Title="{x:Static p:Strings.SettingsWindowTitle}" 
         Height="700" Width="650" 
         MinHeight="600" MinWidth="600"
         Background="Transparent"
@@ -293,7 +294,7 @@
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     
-                    <TextBlock Text="Audio-Pegelwarnung" 
+                    <TextBlock Text="{x:Static p:Strings.SettingsWindowTitle}" 
                                FontSize="16" 
                                FontWeight="SemiBold"
                                Foreground="{StaticResource TextColorSecondary}"
@@ -327,7 +328,7 @@
                           Padding="25,20">
                 <StackPanel>
                     
-                    <TextBlock Text="Einstellungen" 
+                    <TextBlock Text="{x:Static p:Strings.SettingsHeader}" 
                                FontSize="28" 
                                FontWeight="Bold"
                                Foreground="{StaticResource TextColorPrimary}"
@@ -341,7 +342,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Text="Audio-Eingangsgerät" 
+                                <TextBlock Text="{x:Static p:Strings.AudioInputDeviceSectionHeader}" 
                                            FontSize="16" 
                                            FontWeight="SemiBold"
                                            Foreground="{StaticResource TextColorPrimary}"/>
@@ -374,12 +375,12 @@
                                         </Grid.ColumnDefinitions>
                                         
                                         <TextBlock x:Name="CurrentLevelText" 
-                                                   Text="Aktueller Pegel: -18.2 dBFS" 
+                                                   Text="{x:Static p:Strings.CurrentLevelPlaceholder}" 
                                                    FontSize="12"
                                                    Foreground="{StaticResource TextColorSecondary}"/>
                                         <TextBlock Grid.Column="1"
                                                    x:Name="PeakLevelText"
-                                                   Text="Peak: -12.1 dBFS" 
+                                                   Text="{x:Static p:Strings.PeakLevelPlaceholder}" 
                                                    FontSize="12"
                                                    Foreground="{StaticResource TextColorSecondary}"/>
                                     </Grid>
@@ -442,7 +443,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Text="Warnschwellenwerte" 
+                                <TextBlock Text="{x:Static p:Strings.ThresholdConfigSectionHeader}" 
                                            FontSize="16" 
                                            FontWeight="SemiBold"
                                            Foreground="{StaticResource TextColorPrimary}"/>
@@ -457,7 +458,7 @@
                                 </Border>
                             </Grid>
                             
-                            <TextBlock Text="Pegelstufen und zugehörige dBFS-Schwellenwerte definieren." 
+                            <TextBlock Text="{x:Static p:Strings.ThresholdConfigDescription}" 
                                        FontSize="12"
                                        Foreground="{StaticResource TextColorSecondary}"
                                        Margin="0,0,0,15"/>
@@ -482,7 +483,7 @@
                                                  Fill="{StaticResource AccentColorGreen}"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="1"
-                                                   Text="Sicher (Grün) bis:" 
+                                                   Text="{x:Static p:Strings.ThresholdSafeLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorPrimary}"
                                                    VerticalAlignment="Center"
@@ -496,7 +497,7 @@
                                                  TextAlignment="Right"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="4"
-                                                   Text="dBFS" 
+                                                   Text="{x:Static p:Strings.ThresholdUnitLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorSecondary}"
                                                    VerticalAlignment="Center"/>
@@ -516,7 +517,7 @@
                                                  Fill="{StaticResource AccentColorYellow}"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="1"
-                                                   Text="Achtung (Gelb) bis:" 
+                                                   Text="{x:Static p:Strings.ThresholdWarningLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorPrimary}"
                                                    VerticalAlignment="Center"
@@ -530,7 +531,7 @@
                                                  TextAlignment="Right"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="4"
-                                                   Text="dBFS" 
+                                                   Text="{x:Static p:Strings.ThresholdUnitLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorSecondary}"
                                                    VerticalAlignment="Center"/>
@@ -550,7 +551,7 @@
                                                  Fill="{StaticResource AccentColorRed}"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="1"
-                                                   Text="Kritisch (Rot) ab:" 
+                                                   Text="{x:Static p:Strings.ThresholdCriticalLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorPrimary}"
                                                    VerticalAlignment="Center"
@@ -564,7 +565,7 @@
                                                  TextAlignment="Right"
                                                  Margin="0,0,15,0"/>
                                         <TextBlock Grid.Column="4"
-                                                   Text="dBFS" 
+                                                   Text="{x:Static p:Strings.ThresholdUnitLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorSecondary}"
                                                    VerticalAlignment="Center"/>
@@ -572,7 +573,7 @@
                                 </StackPanel>
                             </Border>
                             
-                            <TextBlock Text="Farbverlauf: Standard Grün-Gelb-Rot. (Konfigurierbarkeit idealerweise später)" 
+                            <TextBlock Text="{x:Static p:Strings.ColorGradientInfo}" 
                                        FontSize="12"
                                        Foreground="{StaticResource TextColorSecondary}"
                                        Margin="0,15,0,0"/>
@@ -587,7 +588,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Text="Visuelles Overlay" 
+                                <TextBlock Text="{x:Static p:Strings.VisualOverlaySectionHeader}" 
                                            FontSize="16" 
                                            FontWeight="SemiBold"
                                            Foreground="{StaticResource TextColorPrimary}"/>
@@ -613,21 +614,21 @@
                                 </Grid.RowDefinitions>
                                 
                                 <StackPanel Grid.Column="0" Margin="0,0,8,0">
-                                    <TextBlock Text="Position (Monitorrand):" 
+                                    <TextBlock Text="{x:Static p:Strings.OverlayPositionLabel}" 
                                                FontSize="12"
                                                Foreground="{StaticResource TextColorSecondary}"
                                                Margin="0,0,0,8"/>
                                     <ComboBox x:Name="OverlayPositionComboBox" 
                                               Style="{StaticResource ModernComboBoxStyle}">
-                                        <ComboBoxItem Content="Oberer Rand" IsSelected="True"/>
-                                        <ComboBoxItem Content="Unterer Rand"/>
-                                        <ComboBoxItem Content="Linker Rand"/>
-                                        <ComboBoxItem Content="Rechter Rand"/>
+                                        <ComboBoxItem Content="{x:Static p:Strings.OverlayPositionTop}" IsSelected="True"/>
+                                        <ComboBoxItem Content="{x:Static p:Strings.OverlayPositionBottom}"/>
+                                        <ComboBoxItem Content="{x:Static p:Strings.OverlayPositionLeft}"/>
+                                        <ComboBoxItem Content="{x:Static p:Strings.OverlayPositionRight}"/>
                                     </ComboBox>
                                 </StackPanel>
                                 
                                 <StackPanel Grid.Column="1" Margin="8,0,0,0">
-                                    <TextBlock Text="Dicke/Breite:" 
+                                    <TextBlock Text="{x:Static p:Strings.OverlayThicknessLabel}" 
                                                FontSize="12"
                                                Foreground="{StaticResource TextColorSecondary}"
                                                Margin="0,0,0,8"/>
@@ -641,7 +642,7 @@
                                                  Style="{StaticResource ModernTextBoxStyle}"
                                                  Margin="0,0,8,0"/>
                                         <TextBlock Grid.Column="1"
-                                                   Text="px" 
+                                                   Text="{x:Static p:Strings.OverlayThicknessUnitLabel}" 
                                                    FontSize="14"
                                                    Foreground="{StaticResource TextColorSecondary}"
                                                    VerticalAlignment="Center"/>
@@ -649,7 +650,7 @@
                                 </StackPanel>
                             </Grid>
                             
-                            <TextBlock Text="Dynamische Transparenz und Verhalten im kritischen Bereich gemäß FA04.2, FA04.3." 
+                            <TextBlock Text="{x:Static p:Strings.OverlayBehaviorInfo}" 
                                        FontSize="12"
                                        Foreground="{StaticResource TextColorSecondary}"
                                        Margin="0,15,0,0"/>
@@ -664,7 +665,7 @@
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-                                <TextBlock Text="Akustische Warnung" 
+                                <TextBlock Text="{x:Static p:Strings.AcousticWarningSectionHeader}" 
                                            FontSize="16" 
                                            FontWeight="SemiBold"
                                            Foreground="{StaticResource TextColorPrimary}"/>
@@ -685,7 +686,7 @@
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 
-                                <TextBlock Text="Akustische Warnung (Sinuswelle) aktivieren" 
+                                <TextBlock Text="{x:Static p:Strings.EnableAcousticWarningLabel}" 
                                            FontSize="14"
                                            Foreground="{StaticResource TextColorSecondary}"
                                            VerticalAlignment="Center"/>
@@ -702,7 +703,7 @@
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
                                 
-                                <TextBlock Text="Lautstärke:" 
+                                <TextBlock Text="{x:Static p:Strings.VolumeLabel}" 
                                            FontSize="14"
                                            Foreground="{StaticResource TextColorSecondary}"
                                            VerticalAlignment="Center"
@@ -739,7 +740,7 @@
                             </Grid.ColumnDefinitions>
                             
                             <StackPanel>
-                                <TextBlock Text="Mit Windows starten" 
+                                <TextBlock Text="{x:Static p:Strings.StartWithWindowsLabel}" 
                                            FontSize="16" 
                                            FontWeight="SemiBold"
                                            Foreground="{StaticResource TextColorPrimary}"/>
@@ -763,6 +764,23 @@
                         </Grid>
                     </Border>
                     
+                    <!-- Language Settings Section -->
+                    <Border Style="{StaticResource GlassCardStyle}" Padding="25" Margin="0,15,0,0">
+                        <StackPanel>
+                            <TextBlock Text="{x:Static p:Strings.LanguageSelectionLabel}" 
+                                       FontSize="14"
+                                       FontWeight="Normal" 
+                                       Foreground="{StaticResource TextColorSecondary}"
+                                       Margin="0,0,0,8"/>
+                            <ComboBox x:Name="LanguageComboBox"
+                                      Style="{StaticResource ModernComboBoxStyle}"
+                                      MinWidth="250" 
+                                      HorizontalAlignment="Left">
+                                <!-- ComboBox items will be populated from C# -->
+                            </ComboBox>
+                        </StackPanel>
+                    </Border>
+                    
                 </StackPanel>
             </ScrollViewer>
             
@@ -774,15 +792,15 @@
                     Padding="25,15">
                 <StackPanel Orientation="Horizontal" 
                             HorizontalAlignment="Right">
-                    <Button Content="Einstellungen speichern (FA08)" 
+                    <Button Content="{x:Static p:Strings.SaveSettingsButtonContent}" 
                             Style="{StaticResource ModernButtonStyle}"
                             Margin="0,0,10,0"
                             Click="SaveSettings_Click"/>
-                    <Button Content="Überwachung starten" 
+                    <Button Content="{x:Static p:Strings.StartMonitoringButtonContent}" 
                             Style="{StaticResource PrimaryButtonStyle}"
                             Margin="0,0,10,0"
                             Click="StartMonitoring_Click"/>
-                    <Button Content="In Tray minimieren (FA07)" 
+                    <Button Content="{x:Static p:Strings.MinimizeToTrayButtonContent}" 
                             Style="{StaticResource ModernButtonStyle}"
                             Click="MinimizeToTray_Click"/>
                 </StackPanel>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ This app warns you in real time if your microphone input levels on Windows 11 ar
 
 ---
 
+## Language Settings
+
+The AudioMonitor application supports multiple languages for the user interface. Currently available languages are:
+
+*   English (Default)
+*   German
+
+To change the language:
+1.  Open the **Settings** window.
+2.  Locate the **Language** dropdown menu.
+3.  Select your preferred language (English or Deutsch).
+4.  Click **Save Settings**.
+5.  **Important:** You will need to restart AudioMonitor for the language change to take full effect.
+
+---
+
 ## 3. Performance & Design
 
 *   **Performance:**


### PR DESCRIPTION
I've added comprehensive internationalization (i18n) support to the AudioMonitor application, allowing you to switch between English and German languages.

Key changes include:

- I modified ApplicationSettings to store a language code, defaulting to your system language (German if "de", otherwise English).
- I created .resx resource files (Strings.resx for English, Strings.de.resx for German) and populated them with all user-facing strings from XAML and C# code.
- I ensured the .csproj for AudioMonitor.UI generates a public accessor for the resource files.
- I updated App.xaml.cs to set the application's CurrentUICulture and CurrentCulture at startup based on your saved language preference.
- I refactored all XAML views (MainWindow, SettingsWindow) to use static string resources instead of hardcoded text.
- I updated C# code-behind files (MainWindow.xaml.cs, SettingsWindow.xaml.cs, and DeviceTypeGroupConverter) to retrieve strings from the resource manager. This includes UI text, MessageBoxes, tooltips, and dynamically generated content.
- I added a language selection ComboBox in the SettingsWindow, allowing you to choose between "English" and "Deutsch". The application informs you that a restart is required for language changes to take full effect.
- I updated README.md to document the new language settings feature and guide you on how to change the language.
- I added missing resource keys discovered during implementation (e.g., StatusCritical, CurrentLevelPlaceholder, PeakLevelPlaceholder) and ensured their usage.