### PR TITLE
fix: Resolve build errors and ASIO obsolete warning

### DIFF
--- a/AudioMonitorSolution/AudioMonitor.Core/Services/AudioService.cs
+++ b/AudioMonitorSolution/AudioMonitor.Core/Services/AudioService.cs
@@ -36,6 +36,7 @@ namespace AudioMonitor.Core.Services
         private IWaveIn? _waveInDevice; // Renamed from _capture for clarity
 #if ASIO_SUPPORT
         private AsioOut? _asioOutDevice; // For ASIO operations
+        private float[]? _asioSampleBuffer; // Buffer for ASIO samples
 #endif
         private string? _monitoringDeviceId;
         // private float[]? _asioBuffer; // CS0169: Field is never used. Commenting out for now
@@ -240,20 +241,26 @@ namespace AudioMonitor.Core.Services
         {
             if (_asioOutDevice == null) return;
 
-            // Get samples as interleaved floats. This is often the easiest way to process.
-            float[] samples = e.GetAsInterleavedSamples();
+            int samplesToProcess = e.SamplesPerBuffer * e.Channels;
 
-            if (samples.Length == 0)
+            if (samplesToProcess == 0)
             {
                 CurrentDBFSLevel = -96.0;
                 LevelChanged?.Invoke(this, CurrentDBFSLevel);
                 return;
             }
 
-            float maxSample = 0f;
-            for (int i = 0; i < samples.Length; i++)
+            if (_asioSampleBuffer == null || _asioSampleBuffer.Length < samplesToProcess)
             {
-                float absSample = Math.Abs(samples[i]);
+                _asioSampleBuffer = new float[samplesToProcess];
+            }
+
+            e.GetAsInterleavedSamples(_asioSampleBuffer);
+
+            float maxSample = 0f;
+            for (int i = 0; i < samplesToProcess; i++)
+            {
+                float absSample = Math.Abs(_asioSampleBuffer[i]); // Use the class member buffer
                 if (absSample > maxSample)
                 {
                     maxSample = absSample;

--- a/AudioMonitorSolution/AudioMonitor.UI/AudioMonitor.UI.csproj
+++ b/AudioMonitorSolution/AudioMonitor.UI/AudioMonitor.UI.csproj
@@ -19,16 +19,14 @@
     <Resource Include="image.ico" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="Properties\Strings.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Strings.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Update="Properties\Strings.resx">
+    <EmbeddedResource Include="Properties\Strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <Compile Include="Properties\Strings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Strings.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit addresses the following issues:

1.  Resolves CS0234 errors ("The type or namespace name 'Properties' does not exist in the namespace 'AudioMonitor.UI'") by modifying the AudioMonitor.UI.csproj file. Changed from using `<Compile Update="...">` and `<EmbeddedResource Update="...">` to explicit `<Compile Include="...">` and `<EmbeddedResource Include="...">` for `Strings.Designer.cs` and `Strings.resx` respectively. This ensures more robust inclusion and code generation for the resource files.

2.  Fixes CS0618 warning in AudioMonitor.Core's AudioService.cs related to the obsolete `AsioAudioAvailableEventArgs.GetAsInterleavedSamples()` method. Updated the `OnAsioAudioAvailable` method to use the recommended overload that takes a pre-allocated buffer (`e.GetAsInterleavedSamples(float[] buffer)`), improving performance and adhering to best practices.

These changes should allow the project to build successfully and make the ASIO audio processing more efficient.